### PR TITLE
restore proto types, they are a pain to cast to in typescript

### DIFF
--- a/src/example/index.ts
+++ b/src/example/index.ts
@@ -1,4 +1,9 @@
-import { Audience, OperationType, Snitch, SnitchConfigs } from "../snitch.js";
+import {
+  Audience,
+  OperationType,
+} from "@streamdal/snitch-protos/protos/common.js";
+
+import { Snitch, SnitchConfigs } from "../snitch.js";
 
 const exampleData = {
   boolean_t: true,

--- a/src/internal/register.ts
+++ b/src/internal/register.ts
@@ -1,9 +1,9 @@
+import { Audience } from "@streamdal/snitch-protos/protos/common.js";
 import { ClientType } from "@streamdal/snitch-protos/protos/info.js";
 import { IInternalClient } from "@streamdal/snitch-protos/protos/internal.client.js";
 import { v4 as uuidv4 } from "uuid";
 
 // import { version } from "../../package.json";
-import { Audience } from "../snitch.js";
 import { processResponse } from "./pipeline.js";
 
 export interface RegisterConfigs {

--- a/src/snitch.ts
+++ b/src/snitch.ts
@@ -1,5 +1,6 @@
 import { ChannelCredentials } from "@grpc/grpc-js";
 import { GrpcTransport } from "@protobuf-ts/grpc-transport";
+import { Audience } from "@streamdal/snitch-protos/protos/common.js";
 import {
   IInternalClient,
   InternalClient,
@@ -10,18 +11,6 @@ import {
   StepStatus,
 } from "./internal/process.js";
 import { register } from "./internal/register.js";
-
-export declare enum OperationType {
-  CONSUMER = 1,
-  PRODUCER = 2,
-}
-
-export interface Audience {
-  serviceName: string;
-  componentName: string;
-  operationType: OperationType;
-  operationName: string;
-}
 
 export interface SnitchConfigs {
   snitchUrl?: string;


### PR DESCRIPTION
Using local types turns out to be a pain in typescript because I have to cast them back to the proto types under the hood. Since npm ships this dependency to the clients automatically, I think it's probably ok to just use them.