### PR TITLE
stumbled my way through TS to allow multiple tails on a single audience

### DIFF
--- a/src/internal/audience.ts
+++ b/src/internal/audience.ts
@@ -23,10 +23,10 @@ export const addAudiences = async (configs: Configs) => {
 
 export const addAudience = async ({ configs, audience }: AddAudience) => {
   try {
-    if (internal.audiences.has(audienceKey(audience))) { // DONE
+    if (internal.audiences.has(audienceKey(audience))) {
       return;
     }
-    internal.audiences.set( // DONE
+    internal.audiences.set(
       audienceKey(audience),
       new Map<string, TailStatus>()
     );

--- a/src/internal/audience.ts
+++ b/src/internal/audience.ts
@@ -4,7 +4,7 @@ import {
 } from "@streamdal/snitch-protos/protos/sp_common";
 
 import { Configs } from "../snitch.js";
-import { audienceKey, internal } from "./register.js";
+import { audienceKey, internal, TailStatus } from "./register.js";
 
 export interface AddAudience {
   configs: Configs;
@@ -23,10 +23,13 @@ export const addAudiences = async (configs: Configs) => {
 
 export const addAudience = async ({ configs, audience }: AddAudience) => {
   try {
-    if (internal.audiences.has(audienceKey(audience))) {
+    if (internal.audiences.has(audienceKey(audience))) { // DONE
       return;
     }
-    internal.audiences.set(audienceKey(audience), {});
+    internal.audiences.set( // DONE
+      audienceKey(audience),
+      new Map<string, TailStatus>()
+    );
     const { response } = await configs.grpcClient.newAudience(
       {
         sessionId: configs.sessionId,
@@ -37,8 +40,10 @@ export const addAudience = async ({ configs, audience }: AddAudience) => {
 
     if (response.code !== ResponseCode.OK) {
       console.error("error adding audience", response.message);
+      // TODO: Should we clean up audience map here?
     }
   } catch (error) {
     console.error("error adding audience", error);
+    // TODO: Should we clean up audience map here?
   }
 };

--- a/src/internal/audience.ts
+++ b/src/internal/audience.ts
@@ -26,10 +26,6 @@ export const addAudience = async ({ configs, audience }: AddAudience) => {
     if (internal.audiences.has(audienceKey(audience))) {
       return;
     }
-    internal.audiences.set(
-      audienceKey(audience),
-      new Map<string, TailStatus>()
-    );
     const { response } = await configs.grpcClient.newAudience(
       {
         sessionId: configs.sessionId,
@@ -38,12 +34,15 @@ export const addAudience = async ({ configs, audience }: AddAudience) => {
       { meta: { "auth-token": configs.snitchToken } }
     );
 
-    if (response.code !== ResponseCode.OK) {
+    if (response.code === ResponseCode.OK) {
+      internal.audiences.set(
+        audienceKey(audience),
+        new Map<string, TailStatus>()
+      );
+    } else {
       console.error("error adding audience", response.message);
-      // TODO: Should we clean up audience map here?
     }
   } catch (error) {
     console.error("error adding audience", error);
-    // TODO: Should we clean up audience map here?
   }
 };

--- a/src/internal/pipeline.ts
+++ b/src/internal/pipeline.ts
@@ -119,17 +119,37 @@ export const togglePausePipeline = (
 };
 
 export const tailPipeline = (audience: Audience, { request }: TailCommand) => {
-  console.debug("enabling tail", request);
-  // Create inner map if it doesn't exist
-  if (!internal.audiences.has(audienceKey(audience))) { // DONE
-    internal.audiences.set( // DONE
-      audienceKey(audience),
-      new Map<string, TailStatus>()
-    );
+  console.debug("received a tail command for audience", audience);
+  switch (request.type) {
+    case TailRequestType.START: {
+      console.debug(
+        "received a START tail: adding entry to audiences for tail id",
+        audience
+      );
+      // Create inner map if it doesn't exist
+      if (!internal.audiences.has(audienceKey(audience))) {
+        internal.audiences.set(
+          audienceKey(audience),
+          new Map<string, TailStatus>()
+        );
+      }
+      // Add entry (@JH, OK if overwritten?)
+      internal.audiences.get(audienceKey(audience))?.set(request.Id, {
+        tail: request.type === TailRequestType.START,
+        tailRequestId: request.Id,
+      });
+      break;
+    }
+    case TailRequestType.STOP: {
+      console.debug(
+        "received a STOP tail: removing entry from audiences for tail id",
+        request.Id
+      );
+      internal.audiences.get(audienceKey(audience))?.delete(request.Id);
+      break;
+    }
+    default:
+      console.error("unknown tail request type ", request.type);
+      break;
   }
-  // Add entry (@JH, OK if overwritten?)
-  internal.audiences.get(audienceKey(audience))?.set(request.Id, { // DONE
-    tail: request.type === TailRequestType.START,
-    tailRequestId: request.Id,
-  });
 };

--- a/src/internal/pipeline.ts
+++ b/src/internal/pipeline.ts
@@ -13,7 +13,7 @@ import {
 } from "@streamdal/snitch-protos/protos/sp_pipeline";
 
 import { Configs } from "../snitch.js";
-import { audienceKey, internal } from "./register.js";
+import { audienceKey, internal, TailStatus } from "./register.js";
 
 export type InternalPipeline = Pipeline & {
   paused?: boolean;
@@ -120,7 +120,15 @@ export const togglePausePipeline = (
 
 export const tailPipeline = (audience: Audience, { request }: TailCommand) => {
   console.debug("enabling tail", request);
-  internal.audiences.set(audienceKey(audience), {
+  // Create inner map if it doesn't exist
+  if (!internal.audiences.has(audienceKey(audience))) { // DONE
+    internal.audiences.set( // DONE
+      audienceKey(audience),
+      new Map<string, TailStatus>()
+    );
+  }
+  // Add entry (@JH, OK if overwritten?)
+  internal.audiences.get(audienceKey(audience))?.set(request.Id, { // DONE
     tail: request.type === TailRequestType.START,
     tailRequestId: request.Id,
   });

--- a/src/internal/process.ts
+++ b/src/internal/process.ts
@@ -95,7 +95,7 @@ export const processPipeline = async ({
 }: { configs: PipelineConfigs } & SnitchRequest): Promise<SnitchResponse> => {
   const key = audienceKey(audience);
   const pipeline = internal.pipelines.get(key);
-  const tails = internal.audiences.get(key); // DONE
+  const tails = internal.audiences.get(key);
 
   if (!pipeline || pipeline.paused) {
     const message =

--- a/src/internal/process.ts
+++ b/src/internal/process.ts
@@ -42,7 +42,7 @@ export interface PipelineConfigs {
 
 export interface TailRequest {
   configs: PipelineConfigs;
-  tailStatus?: TailStatus;
+  tails?: Map<string, TailStatus>;
   audience: Audience;
   originalData: Uint8Array;
   newData?: Uint8Array;
@@ -62,28 +62,30 @@ const mapAllSteps = (pipeline: InternalPipeline): EnhancedStep[] =>
 
 export const sendTail = ({
   configs,
-  tailStatus,
+  tails,
   audience,
   originalData,
   newData,
 }: TailRequest) => {
-  try {
-    if (tailStatus?.tail) {
-      const tailResponse = TailResponse.create({
-        timestampNs: (BigInt(new Date().getTime()) * BigInt(1e6)).toString(),
-        type: TailResponseType.PAYLOAD,
-        tailRequestId: tailStatus.tailRequestId,
-        audience,
-        sessionId: configs.sessionId,
-        originalData,
-        newData,
-      });
-      console.debug("sending tail response", tailResponse);
-      void configs.tailCall.requests.send(tailResponse);
+  tails?.forEach((tailStatus, tailRequestId) => {
+    try {
+      if (tailStatus.tail) {
+        const tailResponse = TailResponse.create({
+          timestampNs: (BigInt(new Date().getTime()) * BigInt(1e6)).toString(),
+          type: TailResponseType.PAYLOAD,
+          tailRequestId: tailRequestId,
+          audience,
+          sessionId: configs.sessionId,
+          originalData,
+          newData,
+        });
+        console.debug("sending tail response", tailResponse);
+        void configs.tailCall.requests.send(tailResponse);
+      }
+    } catch (e) {
+      console.error("Error sending tail request", e);
     }
-  } catch (e) {
-    console.error("Error sending tail request", e);
-  }
+  });
 };
 
 export const processPipeline = async ({
@@ -93,7 +95,7 @@ export const processPipeline = async ({
 }: { configs: PipelineConfigs } & SnitchRequest): Promise<SnitchResponse> => {
   const key = audienceKey(audience);
   const pipeline = internal.pipelines.get(key);
-  const tailStatus = internal.audiences.get(key);
+  const tails = internal.audiences.get(key); // DONE
 
   if (!pipeline || pipeline.paused) {
     const message =
@@ -102,7 +104,7 @@ export const processPipeline = async ({
 
     sendTail({
       configs,
-      tailStatus,
+      tails,
       audience,
       originalData: data,
     });
@@ -146,7 +148,7 @@ export const processPipeline = async ({
 
   sendTail({
     configs,
-    tailStatus,
+    tails,
     audience,
     originalData,
     newData: data,

--- a/src/internal/register.ts
+++ b/src/internal/register.ts
@@ -26,7 +26,7 @@ export interface TailStatus {
 export const internal = {
   pipelineInitialized: false,
   pipelines: new Map<string, InternalPipeline>(),
-  audiences: new Map<string, TailStatus>(),
+  audiences: new Map<string, Map<string, TailStatus>>(),
   wasmModules: new Map<string, WasmModule>(),
 };
 


### PR DESCRIPTION
@jacobheric @Adelle-Pitsas 

Discovered a minor issue with node-client - it is not possible to perform more than 1 tail for a given audience. If you launched additional tails for the same audience, your previous tail would stop working.

Reproduce:

1. Run node client via `npm run sandbox`
2. Start a tail via grpcurl
```
grpcurl -plaintext -H "auth-token: 1234" -d @ localhost:9090 protos.External/Tail <<EOM
{
                "audience": {
                "serviceName": "another-test-service",
                "componentName": "another-kafka",
                        "operationType": "OPERATION_TYPE_CONSUMER",
                        "operationName": "test-kafka-consumer"
                }, "type": 1
}
EOM
```
3. In a new tab, start a 2nd tail via grpcurl:
```
grpcurl -plaintext -H "auth-token: 1234" -d @ localhost:9090 protos.External/Tail <<EOM
{
                "audience": {
                "serviceName": "another-test-service",
                "componentName": "another-kafka",
                        "operationType": "OPERATION_TYPE_CONSUMER",
                        "operationName": "test-kafka-consumer"
                }, "type": 1
}
EOM
```
4. 1st grpcurl will stop working; if you start a 3rd, 2nd grpcurl will stop working and so on

The problem was very simple - the node client saves new tail requests into an `map<string, TailStatus>` - then whenever a new tail request comes in, it overwrites the map entry. This PR changes the `map<string, TailStatus>` to a `map<string, map<string, TailStatus>>` and updates all the places where the map gets accesssed.

Tested node client - seems to work great.